### PR TITLE
Add hierarchical clustering option and relax demand constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,10 @@ sk-로 시작하는 본인의 API 키를 입력합니다.
 Demand Space에서 자동 클러스터링된 결과가 마음에 들지 않으면, 마우스로 라벨을 드래그하여 직관적으로 그룹을 합치세요.
 _seg 변수를 만들 때 일관된 규칙(예: 변수명_seg)을 사용하면 관리가 편합니다. (툴에서 자동 처리해 줌)
 
+### 🔄 GitHub 동기화 안내
+
+현재 이 작업 공간에는 Git 원격이 설정되어 있지 않습니다. 모든 커밋은 로컬 리포지토리에만 저장되며, GitHub에 반영하려면 원격 URL을 추가한 뒤 `work` 브랜치(또는 사용 중인 브랜치)를 직접 push 해야 합니다.
+
 ### 👨‍💻 Author: Jihee Cho (https://github.com/jay-lay-down)
 
+See docs/ANALYSIS_SPEC.md for clustering and similarity specifications.

--- a/docs/ANALYSIS_SPEC.md
+++ b/docs/ANALYSIS_SPEC.md
@@ -1,0 +1,16 @@
+# Analysis Specification
+
+This application now offers both **K-Means** and **Hierarchical (Ward) clustering** for Demand Space. The method can be toggled in the Segmentation Setting tab and applies to both segments-as-points and variables-as-points modes.
+
+## Clustering Options
+- **K-Means**: fast, centroid-based partitioning where `k` is specified in advance.
+- **Hierarchical (Ward)**: builds an agglomerative dendrogram and cuts it at `k`, preserving the merge history when exploring cluster structure.
+
+## Similarity / Profile Construction
+- **Segments-as-points**: segment profiles can mix numeric factor scores/targets with categorical targets. Numeric features use means; categorical targets contribute normalized distribution columns (e.g., `target::level`).
+- **Variables-as-points**: still runs PCA or MDS on the numericized variable matrix but now supports as few as two selected variables.
+
+## Practical Notes
+- Manual cluster edits (drag/drop) override base clustering regardless of algorithm choice.
+- Export uses effective cluster assignments and includes per-cluster sheets plus raw data with the cluster label.
+- Non-numeric targets no longer block segmentation; distribution-based features are generated automatically when needed.

--- a/docs/VIEW_APP_CODE.md
+++ b/docs/VIEW_APP_CODE.md
@@ -1,0 +1,9 @@
+# Viewing the full application code
+
+The complete Streamlit application lives in [`app.py`](../app.py), which currently spans roughly 4,000 lines. Because the file is large, the easiest ways to see the entire code are:
+
+- **View directly in this repo:** open `app.py` in your editor or viewer of choice.
+- **Print to the terminal:** run `python scripts/show_app_code.py` from the repository root to stream the whole file to stdout.
+- **Save a copy for sharing:** run `python scripts/show_app_code.py > app_full_code.txt` to create a plain-text snapshot you can share or review offline.
+
+The helper script does not modify the application; it simply reads and prints the file so you can inspect every line in one place.

--- a/scripts/show_app_code.py
+++ b/scripts/show_app_code.py
@@ -1,0 +1,34 @@
+"""
+Utility script to print the entire Streamlit application source.
+
+This script simply streams the contents of app.py to stdout so users can
+view or redirect the full code without needing an editor that handles
+large files. It intentionally avoids any mutations and stops with a clear
+error if the file is missing.
+"""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+APP_FILE = ROOT / "app.py"
+
+
+def main() -> int:
+    if not APP_FILE.exists():
+        sys.stderr.write("app.py not found in repository root.\n")
+        return 1
+
+    try:
+        with APP_FILE.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                sys.stdout.write(line)
+    except BrokenPipeError:
+        # Allow commands like `python scripts/show_app_code.py | head` to
+        # terminate early without surfacing an error to the caller.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a clustering method toggle to run either k-means or hierarchical (Ward) across both demand modes with updated status text
- allow variables-as-points runs with two variables and permit categorical targets by building distributional profiles so segmentation is less numeric-only
- document the updated analysis spec and clustering options in docs/ANALYSIS_SPEC.md and README

## Testing
- python -m compileall app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336ba8f6dc832cb9164e6f7c457daa)