### PR TITLE
Add explicit 'Create New Cluster' flow and stabilize drag-to-add behavior

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ import pickle
 import math
 import ast
 import time  # Added for retry delays
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
@@ -48,6 +49,11 @@ from sklearn.decomposition import PCA, FactorAnalysis
 from sklearn.manifold import MDS
 from sklearn.cluster import AgglomerativeClustering, KMeans
 from sklearn.preprocessing import StandardScaler
+
+# -------------------------------------------------------------------------
+# Logging
+# -------------------------------------------------------------------------
+logger = logging.getLogger(__name__)
 
 # -----------------------------------------------------------------------------
 # Helper Functions: Colors & Formatting
@@ -1628,11 +1634,13 @@ class DemandClusterPlot(pg.PlotWidget):
         self._new_cluster_enabled: bool = False
         self._new_cluster_name: str = ""
         self._new_cluster_color: Optional[QtGui.QColor] = None
+        self._new_cluster_target_id: Optional[int] = None
         self._new_clusters_created: List[Tuple[int, str, QtGui.QColor]] = []
         self._new_cluster_history: List[Tuple[int, List[int], List[int]]] = []
 
     def set_edit_mode_active(self, active: bool):
         self._edit_mode_active = active
+        self.reset_interaction_state(clear_selection=True)
 
     def is_edit_mode_active(self) -> bool:
         return self._edit_mode_active and self._editable_widget
@@ -1646,6 +1654,9 @@ class DemandClusterPlot(pg.PlotWidget):
 
     def set_new_cluster_mode(self, on: bool):
         self._new_cluster_enabled = bool(on)
+        self.reset_interaction_state(clear_selection=True)
+        if not self._new_cluster_enabled:
+            self._new_cluster_target_id = None
 
     def set_new_cluster_template(self, name: str, color: Optional[str]):
         self._new_cluster_name = name or ""
@@ -1656,6 +1667,22 @@ class DemandClusterPlot(pg.PlotWidget):
                 self._new_cluster_color = None
         else:
             self._new_cluster_color = None
+
+    def set_new_cluster_target(self, cid: Optional[int]):
+        self._new_cluster_target_id = int(cid) if cid is not None else None
+
+    def clear_new_cluster_target(self):
+        self._new_cluster_target_id = None
+
+    def reset_interaction_state(self, clear_selection: bool = False):
+        self._dragging = False
+        self._drag_committed = False
+        self._drag_temp_positions = None
+        self._drag_anchor_xy = None
+        if clear_selection:
+            self._selected.clear()
+            self._draw_scatter()
+            self._emit_selection_changed()
 
     def _emit_selection_changed(self):
         if not self._selected:
@@ -1997,18 +2024,39 @@ class DemandClusterPlot(pg.PlotWidget):
                 return None
         return nearest
 
+    def _inside_any_hull(self, drop_xy: Tuple[float, float]) -> bool:
+        pt = QtCore.QPointF(drop_xy[0], drop_xy[1])
+        for hull_item in self._hull_items.values():
+            try:
+                if hull_item.path().contains(pt):
+                    return True
+            except Exception:
+                continue
+        return False
+
     def _min_drag_distance(self) -> float:
         scale = self._cluster_scale()
         return max(0.03 * scale, 0.35)
 
-    def _drop_too_close_to_points(self, drop_xy: Tuple[float, float]) -> bool:
+    def _drop_too_close_to_points(self, drop_xy: Tuple[float, float], ignore_selected: bool = False) -> bool:
         if self._xy.shape[0] == 0:
             return False
+        xy = self._drag_temp_positions if self._drag_temp_positions is not None else self._xy
         scale = self._cluster_scale()
         thr = max(0.08 * scale, 0.8)
-        dx = self._xy[:, 0] - drop_xy[0]
-        dy = self._xy[:, 1] - drop_xy[1]
+        mask = None
+        if ignore_selected and self._selected:
+            mask = np.ones(len(xy), dtype=bool)
+            for i in self._selected:
+                if 0 <= i < len(mask):
+                    mask[i] = False
+        dx = xy[:, 0] - drop_xy[0]
+        dy = xy[:, 1] - drop_xy[1]
         d2 = dx * dx + dy * dy
+        if mask is not None:
+            d2 = d2[mask]
+        if d2.size == 0:
+            return False
         return bool(d2.min() <= thr * thr)
 
     def _resolve_new_cluster_color(self, color: QtGui.QColor, new_cid: int) -> Tuple[QtGui.QColor, bool]:
@@ -2069,7 +2117,10 @@ class DemandClusterPlot(pg.PlotWidget):
         self.sigCoordsChanged.emit()
 
     def _create_cluster_from_drop(self, drop_xy: Tuple[float, float]):
-        new_cid = int(max(self._cluster) if len(self._cluster) else 0) + 1
+        if self._new_cluster_target_id is not None:
+            new_cid = int(self._new_cluster_target_id)
+        else:
+            new_cid = int(max(self._cluster) if len(self._cluster) else 0) + 1
         default_name = f"Cluster {new_cid}"
         base_name = self._new_cluster_name.strip() or default_name
         existing_names = {str(v).strip().lower() for v in self._cluster_names.values()}
@@ -2081,13 +2132,17 @@ class DemandClusterPlot(pg.PlotWidget):
             name = f"{base_name} {suffix}"
             suffix += 1
 
-        color = self._new_cluster_color or self._cluster_color(new_cid, alpha=255)
-        color, replaced = self._resolve_new_cluster_color(QtGui.QColor(color), new_cid)
-        if replaced:
-            QtWidgets.QToolTip.showText(
-                QtGui.QCursor.pos(),
-                "이미 사용 중인 색입니다. 비슷한 다른 색으로 자동 변경했습니다."
-            )
+        is_new_cluster = new_cid not in self._cluster_names
+        if is_new_cluster:
+            color = self._new_cluster_color or self._cluster_color(new_cid, alpha=255)
+            color, replaced = self._resolve_new_cluster_color(QtGui.QColor(color), new_cid)
+            if replaced:
+                QtWidgets.QToolTip.showText(
+                    QtGui.QCursor.pos(),
+                    "이미 사용 중인 색입니다. 비슷한 다른 색으로 자동 변경했습니다."
+                )
+        else:
+            color = self._cluster_custom_colors.get(new_cid, self._cluster_color(new_cid, alpha=255))
 
         if self._drag_temp_positions is not None:
             self._xy = self._drag_temp_positions
@@ -2097,10 +2152,11 @@ class DemandClusterPlot(pg.PlotWidget):
         for i in selected_indices:
             self._cluster[i] = new_cid
 
-        self._cluster_names[new_cid] = name
-        self._cluster_custom_colors[new_cid] = QtGui.QColor(color)
-        self._new_clusters_created.append((new_cid, name, QtGui.QColor(color)))
-        self._new_cluster_history.append((new_cid, selected_indices, prev_clusters))
+        if is_new_cluster:
+            self._cluster_names[new_cid] = name
+            self._cluster_custom_colors[new_cid] = QtGui.QColor(color)
+            self._new_clusters_created.append((new_cid, name, QtGui.QColor(color)))
+            self._new_cluster_history.append((new_cid, selected_indices, prev_clusters))
 
         self._drag_temp_positions = None
         self._drag_anchor_xy = None
@@ -2110,8 +2166,17 @@ class DemandClusterPlot(pg.PlotWidget):
         self._emit_selection_changed()
 
     def _drop_with_snap(self, drop_xy: Tuple[float, float]):
+        inside_hull = self._inside_any_hull(drop_xy)
         dst = self._cluster_at_position(drop_xy, allow_far_new=self._new_cluster_enabled)
+        if self._new_cluster_enabled and not inside_hull:
+            dst = None
         if self._new_cluster_enabled and dst is None:
+            if self._new_cluster_target_id is None:
+                QtWidgets.QToolTip.showText(
+                    QtGui.QCursor.pos(),
+                    "새 클러스터 생성 버튼을 먼저 눌러주세요."
+                )
+                return
             if self._drag_anchor_xy is not None:
                 dist = float(np.hypot(drop_xy[0] - self._drag_anchor_xy[0], drop_xy[1] - self._drag_anchor_xy[1]))
                 if dist < self._min_drag_distance():
@@ -2120,16 +2185,16 @@ class DemandClusterPlot(pg.PlotWidget):
                         "드래그 거리가 너무 짧아 새 클러스터 생성이 취소되었습니다."
                     )
                     return
-            if self._drop_too_close_to_points(drop_xy):
+            if self._drop_too_close_to_points(drop_xy, ignore_selected=True):
                 QtWidgets.QToolTip.showText(
                     QtGui.QCursor.pos(),
                     "기존 포인트/클러스터 근처에서는 새 클러스터를 만들 수 없습니다."
                 )
                 return
-            if len(self._selected) < 3:
+            if not self._selected:
                 QtWidgets.QToolTip.showText(
                     QtGui.QCursor.pos(),
-                    "새 클러스터 생성은 최소 3개 포인트가 필요합니다."
+                    "새 클러스터 생성은 포인트 선택이 필요합니다."
                 )
                 return
             self._create_cluster_from_drop(drop_xy)
@@ -2142,8 +2207,23 @@ class DemandClusterPlot(pg.PlotWidget):
             return
 
         if ev.isStart():
+            logger.debug(
+                "drag_start edit=%s new_cluster=%s free_move=%s selected=%s pos=%s",
+                self._edit_mode_active,
+                self._new_cluster_enabled,
+                self._free_move_points,
+                len(self._selected),
+                pos,
+            )
             i = self._nearest_point(pos[0], pos[1])
             if i is None:
+                if self._selected and (self._new_cluster_enabled or self._free_move_points):
+                    self._dragging = True
+                    self._drag_committed = False
+                    self._drag_temp_positions = self._xy.copy()
+                    self._drag_anchor_xy = (pos[0], pos[1])
+                    ev.accept()
+                    return
                 ev.ignore()
                 return
             if i not in self._selected:
@@ -2163,6 +2243,13 @@ class DemandClusterPlot(pg.PlotWidget):
         ev.accept()
 
         if ev.isFinish():
+            logger.debug(
+                "drag_finish free_move=%s new_cluster=%s selected=%s pos=%s",
+                self._free_move_points,
+                self._new_cluster_enabled,
+                len(self._selected),
+                pos,
+            )
             if self._drag_committed:
                 return
             self._drag_committed = True
@@ -2173,6 +2260,13 @@ class DemandClusterPlot(pg.PlotWidget):
                 self._drop_with_snap(pos)
             return
 
+        logger.debug(
+            "drag_move free_move=%s new_cluster=%s selected=%s pos=%s",
+            self._free_move_points,
+            self._new_cluster_enabled,
+            len(self._selected),
+            pos,
+        )
         if self._drag_temp_positions is not None and self._selected and self._drag_anchor_xy is not None:
             dx = pos[0] - self._drag_anchor_xy[0]
             dy = pos[1] - self._drag_anchor_xy[1]
@@ -5969,9 +6063,10 @@ class IntegratedApp(QtWidgets.QMainWindow):
         left = QtWidgets.QVBoxLayout()
 
         toggle_group = QtWidgets.QGroupBox("Edit Mode (Toggle)")
+        toggle_group.setSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Fixed)
         tgl_lay = QtWidgets.QVBoxLayout(toggle_group)
-        tgl_lay.setContentsMargins(6, 6, 6, 6)
-        tgl_lay.setSpacing(4)
+        tgl_lay.setContentsMargins(2, 2, 2, 2)
+        tgl_lay.setSpacing(2)
         self.radio_edit_points = QtWidgets.QRadioButton("Edit Points (Move/Merge)")
         self.radio_edit_points.setToolTip("Drag points to move/merge. Pan is locked.")
         self.radio_edit_view = QtWidgets.QRadioButton("View/Pan Mode")
@@ -6008,6 +6103,11 @@ class IntegratedApp(QtWidgets.QMainWindow):
 
         add_group = QtWidgets.QGroupBox("Add Cluster (Drag into empty space)")
         add_lay = QtWidgets.QVBoxLayout(add_group)
+        self.btn_create_new_cluster = QtWidgets.QPushButton("새 클러스터 생성")
+        style_button(self.btn_create_new_cluster, level=1)
+        self.btn_create_new_cluster.clicked.connect(self._on_create_new_cluster_clicked)
+        self._register_text(self.btn_create_new_cluster, "새 클러스터 생성", "Create New Cluster")
+        add_lay.addWidget(self.btn_create_new_cluster)
         self.chk_add_cluster_mode = QtWidgets.QCheckBox("Enable drag-to-add cluster")
         self.chk_add_cluster_mode.setToolTip(
             "Select points, enable, then drop into an empty area to spawn a new cluster with the chosen name/color."
@@ -6040,6 +6140,8 @@ class IntegratedApp(QtWidgets.QMainWindow):
         self._register_text(self.btn_undo_new_cluster, "새 클러스터 되돌리기", "Undo Last Cluster")
         add_lay.addWidget(self.btn_undo_new_cluster)
 
+        self._pending_new_cluster_id = None
+        self._pending_new_cluster_dirty = False
         self._update_new_cluster_color_button()
         self._apply_new_cluster_template()
         self._on_new_cluster_toggle(False)
@@ -6127,6 +6229,9 @@ class IntegratedApp(QtWidgets.QMainWindow):
     def _on_edit_mode_toggled(self):
         is_point_edit = self.radio_edit_points.isChecked()
         self.plot_edit.set_edit_mode_active(is_point_edit)
+        self.chk_add_cluster_mode.setEnabled(is_point_edit)
+        if not is_point_edit and self.chk_add_cluster_mode.isChecked():
+            self.chk_add_cluster_mode.setChecked(False)
         if is_point_edit:
             self._set_status("Edit Mode: Drag points/labels enabled. (Pan locked)")
         else:
@@ -6256,6 +6361,8 @@ class IntegratedApp(QtWidgets.QMainWindow):
             return
         name = self.txt_new_cluster_name.text().strip()
         self._apply_new_cluster_template()
+        if self.chk_add_cluster_mode.isChecked():
+            return
         if self._active_cluster_id is None:
             return
         if not name:
@@ -6272,11 +6379,41 @@ class IntegratedApp(QtWidgets.QMainWindow):
         self.txt_new_cluster_name.setEnabled(bool(checked))
         self.btn_new_cluster_color.setEnabled(bool(checked))
         self.lbl_new_cluster_color.setEnabled(bool(checked))
+        self.btn_create_new_cluster.setEnabled(bool(checked))
         self.plot_edit.set_new_cluster_mode(bool(checked))
         if checked:
             self._active_cluster_id = None
+            self.tbl_cluster_summary.clearSelection()
+            self._active_cluster_id = None
             self._set_new_cluster_default_name(force=True)
             self._apply_new_cluster_template()
+        else:
+            self._pending_new_cluster_id = None
+            self._pending_new_cluster_dirty = False
+            self.plot_edit.clear_new_cluster_target()
+
+    def _on_create_new_cluster_clicked(self):
+        if not self.chk_add_cluster_mode.isChecked():
+            self.chk_add_cluster_mode.setChecked(True)
+        if self._pending_new_cluster_id is not None and self._pending_new_cluster_dirty:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "새 클러스터 미저장",
+                "저장되지 않은 새 클러스터가 있습니다.\n"
+                "세그 결과 저장 후 새 클러스터를 생성하세요.",
+            )
+            return
+        next_id = self._next_cluster_id()
+        self._pending_new_cluster_id = int(next_id)
+        self._pending_new_cluster_dirty = False
+        current_name = self.txt_new_cluster_name.text().strip()
+        if not current_name or self._is_default_cluster_name(current_name):
+            self._suppress_cluster_name_update = True
+            self.txt_new_cluster_name.setText(f"Cluster {next_id}")
+            self._suppress_cluster_name_update = False
+        self._apply_new_cluster_template()
+        self.plot_edit.set_new_cluster_target(next_id)
+        self._set_status(f"새 클러스터 {next_id} 생성 모드입니다.")
 
     def _pick_new_cluster_color(self):
         col = QtWidgets.QColorDialog.getColor(QtGui.QColor(self._new_cluster_color_hex), self, "Select Cluster Color")
@@ -6284,6 +6421,8 @@ class IntegratedApp(QtWidgets.QMainWindow):
             self._new_cluster_color_hex = col.name()
             self._update_new_cluster_color_button()
             self._apply_new_cluster_template()
+            if self.chk_add_cluster_mode.isChecked():
+                return
             if self._active_cluster_id is not None:
                 self.state.cluster_colors[int(self._active_cluster_id)] = col.name()
                 self.plot_edit.set_cluster_colors(self.state.cluster_colors)
@@ -6364,6 +6503,8 @@ class IntegratedApp(QtWidgets.QMainWindow):
     def _on_cluster_summary_selection_changed(self, *_args):
         if not hasattr(self, "tbl_cluster_summary"):
             return
+        if self.chk_add_cluster_mode.isChecked():
+            return
         if self._suppress_summary_selection:
             return
 
@@ -6412,6 +6553,10 @@ class IntegratedApp(QtWidgets.QMainWindow):
 
     def _on_plot_selection_changed(self, cid: Optional[int]):
         if not hasattr(self, "tbl_cluster_summary"):
+            return
+        if self.chk_add_cluster_mode.isChecked():
+            self._active_cluster_id = None
+            self._set_new_cluster_default_name()
             return
         if self._suppress_summary_selection:
             return
@@ -6521,6 +6666,10 @@ class IntegratedApp(QtWidgets.QMainWindow):
             self._seg_save_counter = getattr(self, "_seg_save_counter", 1) + 1
             self.txt_seg_save_name.setText(f"seg_result_{self._seg_save_counter}")
             self._set_status(f"세그 결과를 '{col}' 컬럼에 저장했습니다.")
+            self._pending_new_cluster_id = None
+            self._pending_new_cluster_dirty = False
+            if hasattr(self, "plot_edit"):
+                self.plot_edit.clear_new_cluster_target()
         except Exception as e:
             show_error(self, "Save Seg Result Error", e)
 
@@ -6577,6 +6726,10 @@ class IntegratedApp(QtWidgets.QMainWindow):
 
     def _on_manual_clusters_changed(self):
         self._sync_clusters_from_edit_plot("Manual clusters updated.")
+        pending_id = getattr(self, "_pending_new_cluster_id", None)
+        if pending_id is not None and self.state.cluster_assign is not None:
+            if int(pending_id) in set(map(int, self.state.cluster_assign.unique())):
+                self._pending_new_cluster_dirty = True
 
     def _on_manual_coords_changed(self):
         if self.state.demand_xy is None:


### PR DESCRIPTION
### Motivation
- Make new-cluster creation explicit so multiple drags populate a single declared cluster until the segmentation is saved and prevent accidental repeated new-cluster creation. 
- Prevent stale/incorrect drag state and proximity checks (e.g. ignore points currently being dragged) that caused broken assignments when dragging into empty space. 
- Surface a clear UI trigger and reduce the height of the Edit Mode radio group for a tighter layout.

### Description
- Introduced a target-based new-cluster flow by adding `self._new_cluster_target_id` and APIs `set_new_cluster_target` / `clear_new_cluster_target` and requiring the new `Create New Cluster` button to declare the pending cluster target before drag-to-add. 
- Added UI button `btn_create_new_cluster` and handler `_on_create_new_cluster_clicked`, plus pending-tracking fields `self._pending_new_cluster_id` and `self._pending_new_cluster_dirty` and logic to warn and block creating a new pending cluster while a previous pending cluster is unsaved. 
- Reworked drop and creation logic so `_create_cluster_from_drop` reuses the declared target id (instead of creating a new id each drop), `_drop_with_snap` uses `_inside_any_hull` to avoid accidental new-cluster creation over existing hulls and shows a tooltip if no target was declared, and `_drop_too_close_to_points` now accepts `ignore_selected` and uses `_drag_temp_positions` to ignore points being dragged. 
- Stabilized drag state by adding `reset_interaction_state` and calling it from `set_new_cluster_mode` / `set_edit_mode_active`, allowed dragging to start from empty space when a selection exists and `new_cluster` or `free_move` is enabled, added debug `logger` messages for drag `start`/`move`/`finish`, and tightened the Edit Mode group size/margins (`setSizePolicy` + reduced `setContentsMargins`/`setSpacing`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69688aab3a74832cbfa1858fac0ac453)