### PR TITLE
Ignore source cluster in proximity check when creating new cluster from multi-select drag

### DIFF
--- a/app.py
+++ b/app.py
@@ -2195,19 +2195,6 @@ class DemandClusterPlot(pg.PlotWidget):
                         "드래그 거리가 너무 짧아 새 클러스터 생성이 취소되었습니다."
                     )
                     return
-            ignore_clusters = set()
-            if len(self._selected) >= 2:
-                ignore_clusters = {int(self._cluster[i]) for i in self._selected}
-            if self._drop_too_close_to_points(
-                drop_xy,
-                ignore_selected=True,
-                ignore_clusters=ignore_clusters,
-            ):
-                QtWidgets.QToolTip.showText(
-                    QtGui.QCursor.pos(),
-                    "기존 포인트/클러스터 근처에서는 새 클러스터를 만들 수 없습니다."
-                )
-                return
             if not self._selected:
                 QtWidgets.QToolTip.showText(
                     QtGui.QCursor.pos(),

--- a/app.py
+++ b/app.py
@@ -2038,18 +2038,28 @@ class DemandClusterPlot(pg.PlotWidget):
         scale = self._cluster_scale()
         return max(0.03 * scale, 0.35)
 
-    def _drop_too_close_to_points(self, drop_xy: Tuple[float, float], ignore_selected: bool = False) -> bool:
+    def _drop_too_close_to_points(
+        self,
+        drop_xy: Tuple[float, float],
+        ignore_selected: bool = False,
+        ignore_clusters: Optional[set[int]] = None,
+    ) -> bool:
         if self._xy.shape[0] == 0:
             return False
         xy = self._drag_temp_positions if self._drag_temp_positions is not None else self._xy
         scale = self._cluster_scale()
         thr = max(0.08 * scale, 0.8)
         mask = None
-        if ignore_selected and self._selected:
+        if ignore_selected or ignore_clusters:
             mask = np.ones(len(xy), dtype=bool)
-            for i in self._selected:
-                if 0 <= i < len(mask):
-                    mask[i] = False
+            if ignore_selected and self._selected:
+                for i in self._selected:
+                    if 0 <= i < len(mask):
+                        mask[i] = False
+            if ignore_clusters:
+                for idx, cid in enumerate(self._cluster):
+                    if int(cid) in ignore_clusters:
+                        mask[idx] = False
         dx = xy[:, 0] - drop_xy[0]
         dy = xy[:, 1] - drop_xy[1]
         d2 = dx * dx + dy * dy
@@ -2185,7 +2195,14 @@ class DemandClusterPlot(pg.PlotWidget):
                         "드래그 거리가 너무 짧아 새 클러스터 생성이 취소되었습니다."
                     )
                     return
-            if self._drop_too_close_to_points(drop_xy, ignore_selected=True):
+            ignore_clusters = set()
+            if len(self._selected) >= 2:
+                ignore_clusters = {int(self._cluster[i]) for i in self._selected}
+            if self._drop_too_close_to_points(
+                drop_xy,
+                ignore_selected=True,
+                ignore_clusters=ignore_clusters,
+            ):
                 QtWidgets.QToolTip.showText(
                     QtGui.QCursor.pos(),
                     "기존 포인트/클러스터 근처에서는 새 클러스터를 만들 수 없습니다."


### PR DESCRIPTION
### Motivation
- Multi-point drag-to-add was being blocked by the proximity guard because points remained near their original cluster, preventing intended new-cluster creation when the user intentionally dragged multiple points away.

### Description
- Added an optional `ignore_clusters: Optional[set[int]]` parameter to `_drop_too_close_to_points` and updated its mask logic to exclude indices that belong to any cluster in `ignore_clusters` as well as optionally excluding selected indices via `ignore_selected`.
- Changed the mask activation condition to use `if ignore_selected or ignore_clusters:` so proximity masking is applied only when needed.
- When attempting a drag-to-add new cluster, compute `ignore_clusters = {int(self._cluster[i]) for i in self._selected}` when `len(self._selected) >= 2` and pass it into `_drop_too_close_to_points`, allowing the source cluster to be ignored for multi-point moves while retaining protection for single-point drags and other clusters.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b1ed47b0832c98b8ead73a2077cb)